### PR TITLE
Add recipes section to website

### DIFF
--- a/_build/recipes/array.md
+++ b/_build/recipes/array.md
@@ -1,0 +1,46 @@
+---
+title: Array
+layout: default
+nav_order: 2
+parent: Recipes
+---
+
+# Array Recipes
+
+Source: `array.spq`
+
+---
+
+## sk_in_array
+
+Puts value in an array if value isn't an array itself.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `value` | any |
+
+```supersql
+sk_in_array(1)
+-- => [1]
+
+sk_in_array([1])
+-- => [1]
+```
+
+---
+
+## sk_array_flatten
+
+Flattens an array of arrays into a single array.
+
+**Type:** operator
+
+```supersql
+[1,2,[3,4],5] | sk_array_flatten
+-- => [1,2,3,4,5]
+
+[[1,2],[3,4]] | sk_array_flatten
+-- => [1,2,3,4]
+```

--- a/_build/recipes/character.md
+++ b/_build/recipes/character.md
@@ -1,0 +1,74 @@
+---
+title: Character
+layout: default
+nav_order: 4
+parent: Recipes
+---
+
+# Character Recipes
+
+Source: `character.spq` (includes `string.spq`)
+
+---
+
+## sk_seq
+
+Generates a sequence 0..n-1 (like generate_series).
+
+**Type:** operator
+
+| Argument | Description |
+|----------|-------------|
+| `n` | Number of elements to generate |
+
+```supersql
+sk_seq(3)
+-- => 0, 1, 2
+```
+
+---
+
+## sk_hex_digits
+
+Returns the 16 hex digit characters as an array.
+
+**Type:** function
+
+```supersql
+sk_hex_digits()
+-- => ["0","1","2","3","4","5","6","7","8","9","a","b","c","d","e","f"]
+```
+
+---
+
+## sk_chr
+
+Converts an integer (0-127) to its ASCII character.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `code` | ASCII code (0-127) |
+
+```supersql
+sk_chr(65)
+-- => 'A'
+```
+
+---
+
+## sk_alpha
+
+Converts 1-26 to A-Z.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `n` | Number 1-26 |
+
+```supersql
+sk_alpha(3)
+-- => 'C'
+```

--- a/_build/recipes/escape.md
+++ b/_build/recipes/escape.md
@@ -1,0 +1,125 @@
+---
+title: Escape
+layout: default
+nav_order: 7
+parent: Recipes
+---
+
+# Escape Recipes
+
+Source: `escape.spq`
+
+Functions for safely escaping values for CSV, TSV, and shell contexts, plus
+patterns for safe text ingestion from shell pipelines.
+
+---
+
+## sk_csv_field
+
+Escapes a string for use as a CSV field per RFC 4180. Wraps in double quotes
+and doubles internal quotes when the value contains commas, quotes, or
+newlines. Plain values pass through unchanged.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `s` | The string to escape |
+
+```supersql
+sk_csv_field('plain')
+-- => 'plain'
+
+sk_csv_field('hello, world')
+-- => quoted and wrapped
+```
+
+---
+
+## sk_csv_row
+
+Builds a CSV row from an array of values. Each element is cast to string and
+escaped with sk_csv_field, then joined with commas.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `arr` | Array of values to format as a CSV row |
+
+---
+
+## sk_shell_quote
+
+Wraps a string in POSIX shell single quotes. Internal single quotes are escaped
+so the result is safe for shell interpolation. Protects against injection of `$`,
+backticks, and other shell metacharacters.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `s` | The string to quote |
+
+```supersql
+sk_shell_quote('hello world')
+-- => single-quoted string
+
+sk_shell_quote('has $var')
+-- => single-quoted, $ not expanded
+```
+
+---
+
+## sk_tsv_field
+
+Escapes a value for use in a TSV field. Casts to string, then replaces literal
+tab and newline characters with their backslash-escaped forms.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `s` | The value to escape |
+
+---
+
+## Shell Patterns for Safe Text Ingestion
+
+The key insight: never interpolate untrusted text into a SuperQL string literal.
+Pipe raw text through `super` with `-i line` and let the serializer handle
+escaping. These patterns work from any language that can spawn a subprocess.
+
+### safe_text_to_record
+
+Pipe raw text into super to build a record without string interpolation.
+
+```bash
+echo "$text" | super -s -i line -c "values {body: this}" -
+```
+
+### safe_text_to_string
+
+Pipe raw text through super to get a properly escaped SUP string literal.
+
+```bash
+echo "$text" | super -s -i line -c "values this" -
+```
+
+### safe_multiline_to_record
+
+Collapse multiline text into a single record field.
+
+```bash
+echo "$text" | super -s -i line \
+  -c 'aggregate s:=collect(this) | values {body: join(s, "\n")}' -
+```
+
+### safe_append_to_sup_file
+
+Append a timestamped record with raw text to a `.sup` file.
+
+```bash
+echo "$text" | super -s -i line \
+  -c "values {ts: now(), body: this}" - >> data.sup
+```

--- a/_build/recipes/format.md
+++ b/_build/recipes/format.md
@@ -1,0 +1,32 @@
+---
+title: Format
+layout: default
+nav_order: 5
+parent: Recipes
+---
+
+# Format Recipes
+
+Source: `format.spq`
+
+---
+
+## sk_format_bytes
+
+Returns the size in bytes in human readable format.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `value` | Must be castable to uint64 |
+
+```supersql
+sk_format_bytes(1048576)
+-- => '1 MB'
+
+sk_format_bytes(0)
+-- => '0 B'
+```
+
+Supports units up to EB (exabytes). The full unit list: B, KB, MB, GB, TB, PB, EB.

--- a/_build/recipes/index.md
+++ b/_build/recipes/index.md
@@ -1,0 +1,23 @@
+---
+title: Recipes
+layout: default
+has_children: true
+nav_order: 5
+---
+
+# Recipes
+
+Reusable SuperSQL functions and operators for common tasks. Include them in your
+queries with `from` or `-I`:
+
+```supersql
+from 'string.spq' | values sk_capitalize('hello')
+```
+
+```bash
+super -I string.spq -c "values sk_capitalize('hello')"
+```
+
+Recipe source files are available in the
+[superdb-mcp](https://github.com/chrismo/superdb-mcp/tree/main/docs/recipes)
+repository.

--- a/_build/recipes/integer.md
+++ b/_build/recipes/integer.md
@@ -1,0 +1,77 @@
+---
+title: Integer
+layout: default
+nav_order: 3
+parent: Recipes
+---
+
+# Integer Recipes
+
+Source: `integer.spq`
+
+---
+
+## sk_clamp
+
+Clamps a value between min and max.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `i` | The value to clamp. |
+| `min` | The minimum value. |
+| `max` | The maximum value. |
+
+```supersql
+sk_clamp(1, 2, 3)
+-- => 2
+
+sk_clamp(4, 2, 3)
+-- => 3
+
+sk_clamp(2, 2, 3)
+-- => 2
+```
+
+---
+
+## sk_min
+
+Returns the minimum of two values.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `a` | The first value. |
+| `b` | The second value. |
+
+```supersql
+sk_min(1, 2)
+-- => 1
+
+sk_min(3, 2)
+-- => 2
+```
+
+---
+
+## sk_max
+
+Returns the maximum of two values.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `a` | The first value. |
+| `b` | The second value. |
+
+```supersql
+sk_max(1, 2)
+-- => 2
+
+sk_max(3, 2)
+-- => 3
+```

--- a/_build/recipes/records.md
+++ b/_build/recipes/records.md
@@ -1,0 +1,54 @@
+---
+title: Records
+layout: default
+nav_order: 6
+parent: Recipes
+---
+
+# Record Recipes
+
+Source: `records.spq` (includes `array.spq`)
+
+---
+
+## sk_keys
+
+Returns the keys of the top-level fields in a record. This does not go deep
+into nested records.
+
+**Type:** operator
+
+```supersql
+{a:1,b:{c:333}} | sk_keys
+-- => ['a','b']
+
+{x:10,y:20,z:30} | sk_keys
+-- => ['x','y','z']
+```
+
+---
+
+## sk_merge_records
+
+Merges an array of records into a single record by combining the fields. If
+there are duplicate keys, the last one wins.
+
+**Type:** operator
+
+```supersql
+[{a:1},{b:{c:333}}] | sk_merge_records
+-- => {a:1,b:{c:333}}
+```
+
+---
+
+## sk_add_ids
+
+Prepends an incrementing id field to each record. Always returns an array.
+
+**Type:** operator
+
+```supersql
+[{a:3},{b:4}] | sk_add_ids
+-- => [{id:1,a:3},{id:2,b:4}]
+```

--- a/_build/recipes/string.md
+++ b/_build/recipes/string.md
@@ -1,0 +1,117 @@
+---
+title: String
+layout: default
+nav_order: 1
+parent: Recipes
+---
+
+# String Recipes
+
+Source: `string.spq` (includes `integer.spq`)
+
+---
+
+## sk_slice
+
+Returns a slice of the string passed in, even if indexes are out of range.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `s` | The string to slice. |
+| `start` | Starting index, zero-based, inclusive. |
+| `end` | Ending index, exclusive. |
+
+```supersql
+sk_slice('howdy')
+-- => 'Howdy'
+```
+
+---
+
+## sk_capitalize
+
+Upper the first character of the string, lower the remaining string.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `s` | The string to capitalize. |
+
+```supersql
+sk_capitalize('hoWDy')
+-- => 'Howdy'
+```
+
+---
+
+## sk_titleize
+
+Splits string by space and capitalizes each word.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `s` | The string to titleize |
+
+```supersql
+sk_titleize('once uPON A TIME')
+-- => 'Once Upon A Time'
+```
+
+---
+
+## sk_pad_left
+
+Inserts pad_char to the left of the string until it reaches target_length.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `s` | The string to pad |
+| `pad_char` | The character to pad with |
+| `target_length` | The target length of the string |
+
+```supersql
+values sk_pad_left('abc', ' ', 5)
+-- => '  abc'
+```
+
+---
+
+## sk_pad_right
+
+Inserts pad_char to the right of the string until it reaches target_length.
+
+**Type:** function
+
+| Argument | Description |
+|----------|-------------|
+| `s` | The string to pad |
+| `pad_char` | The character to pad with |
+| `target_length` | The target length of the string |
+
+```supersql
+values sk_pad_right('abc', ' ', 5)
+-- => 'abc  '
+```
+
+---
+
+## sk_urldecode
+
+URL decoder for SuperDB. Splits on `%`, decodes each hex-encoded segment, and joins back together.
+
+**Type:** operator
+
+| Argument | Description |
+|----------|-------------|
+| `url` | The URL-encoded string to decode |
+
+```bash
+super -I string.spq -s -c 'values sk_urldecode("%2Ftavern%20test")' -
+```

--- a/index.md
+++ b/index.md
@@ -22,6 +22,15 @@ Step-by-step tutorials covering common SuperDB patterns:
 - [{{ tutorial.title }}]({{ tutorial.url | relative_url }})
 {% endfor %}
 
+## Recipes
+
+Reusable SuperSQL functions and operators:
+
+{% assign recipes = site.pages | where_exp: "page", "page.parent == 'Recipes'" | sort: "nav_order" %}
+{% for recipe in recipes %}
+- [{{ recipe.title }}]({{ recipe.url | relative_url }})
+{% endfor %}
+
 ---
 
 Content is auto-synced from [superdb-mcp](https://github.com/chrismo/superdb-mcp), which serves this material through the SuperDB MCP server for use with coding agents.


### PR DESCRIPTION
Document all SuperKit recipe functions (string, array, integer, character,
format, records, escape) as browsable pages on the Jekyll site, with a
parent index page and Recipes section on the homepage.

https://claude.ai/code/session_012dhrHYqypaFKT7JR8wTimP