### PR TITLE
Add implementation details to all recipe documentation

### DIFF
--- a/_build/recipes/array.md
+++ b/_build/recipes/array.md
@@ -29,6 +29,14 @@ sk_in_array([1])
 -- => [1]
 ```
 
+**Implementation:**
+
+```supersql
+fn sk_in_array(value): (
+  kind(value) == "array" ? value : [value]
+)
+```
+
 ---
 
 ## sk_array_flatten
@@ -45,15 +53,9 @@ Flattens an array of arrays into a single array.
 -- => [1,2,3,4]
 ```
 
----
-
-## Implementation
+**Implementation:**
 
 ```supersql
-fn sk_in_array(value): (
-  kind(value) == "array" ? value : [value]
-)
-
 op sk_array_flatten: (
   this::string
   | this[1:-1]

--- a/_build/recipes/character.md
+++ b/_build/recipes/character.md
@@ -26,6 +26,17 @@ sk_seq(3)
 -- => 0, 1, 2
 ```
 
+**Implementation:**
+
+```supersql
+op sk_seq(n): (
+  split(sk_pad_left('', '0', n), '')
+  | unnest this
+  | count
+  | values count - 1
+)
+```
+
 ---
 
 ## sk_hex_digits
@@ -37,6 +48,14 @@ Returns the 16 hex digit characters as an array.
 ```supersql
 sk_hex_digits()
 -- => ["0","1","2","3","4","5","6","7","8","9","a","b","c","d","e","f"]
+```
+
+**Implementation:**
+
+```supersql
+fn sk_hex_digits(): (
+  split("0123456789abcdef", "")
+)
 ```
 
 ---
@@ -56,6 +75,15 @@ sk_chr(65)
 -- => 'A'
 ```
 
+**Implementation:**
+
+```supersql
+fn sk_chr(code): (
+  let d = sk_hex_digits() |
+  hex(f'{d[code/16]}{d[code%16]}')::string
+)
+```
+
 ---
 
 ## sk_alpha
@@ -73,29 +101,9 @@ sk_alpha(3)
 -- => 'C'
 ```
 
----
-
-## Implementation
+**Implementation:**
 
 ```supersql
--- includes string.spq
-
-op sk_seq(n): (
-  split(sk_pad_left('', '0', n), '')
-  | unnest this
-  | count
-  | values count - 1
-)
-
-fn sk_hex_digits(): (
-  split("0123456789abcdef", "")
-)
-
-fn sk_chr(code): (
-  let d = sk_hex_digits() |
-  hex(f'{d[code/16]}{d[code%16]}')::string
-)
-
 fn sk_alpha(n): (
   sk_chr(64 + n)
 )

--- a/_build/recipes/escape.md
+++ b/_build/recipes/escape.md
@@ -34,6 +34,16 @@ sk_csv_field('hello, world')
 -- => quoted and wrapped
 ```
 
+**Implementation:**
+
+```supersql
+fn sk_csv_field(s): (
+  grep("[,\"\n]", s)
+    ? f"\"{replace(s, "\"", "\"\"")}\""
+    : s
+)
+```
+
 ---
 
 ## sk_csv_row
@@ -46,6 +56,14 @@ escaped with sk_csv_field, then joined with commas.
 | Argument | Description |
 |----------|-------------|
 | `arr` | Array of values to format as a CSV row |
+
+**Implementation:**
+
+```supersql
+fn sk_csv_row(arr): (
+  join([unnest arr | values sk_csv_field(cast(this, <string>))], ",")
+)
+```
 
 ---
 
@@ -69,6 +87,14 @@ sk_shell_quote('has $var')
 -- => single-quoted, $ not expanded
 ```
 
+**Implementation:**
+
+```supersql
+fn sk_shell_quote(s): (
+  f"'{replace(s, "'", "'\\''")}'"
+)
+```
+
 ---
 
 ## sk_tsv_field
@@ -81,6 +107,14 @@ tab and newline characters with their backslash-escaped forms.
 | Argument | Description |
 |----------|-------------|
 | `s` | The value to escape |
+
+**Implementation:**
+
+```supersql
+fn sk_tsv_field(s): (
+  replace(replace(cast(s, <string>), "\t", "\\t"), "\n", "\\n")
+)
+```
 
 ---
 
@@ -122,28 +156,4 @@ Append a timestamped record with raw text to a `.sup` file.
 ```bash
 echo "$text" | super -s -i line \
   -c "values {ts: now(), body: this}" - >> data.sup
-```
-
----
-
-## Implementation
-
-```supersql
-fn sk_csv_field(s): (
-  grep("[,\"\n]", s)
-    ? f"\"{replace(s, "\"", "\"\"")}\""
-    : s
-)
-
-fn sk_csv_row(arr): (
-  join([unnest arr | values sk_csv_field(cast(this, <string>))], ",")
-)
-
-fn sk_shell_quote(s): (
-  f"'{replace(s, "'", "'\\''")}'"
-)
-
-fn sk_tsv_field(s): (
-  replace(replace(cast(s, <string>), "\t", "\\t"), "\n", "\\n")
-)
 ```

--- a/_build/recipes/format.md
+++ b/_build/recipes/format.md
@@ -31,9 +31,7 @@ sk_format_bytes(0)
 
 Supports units up to EB (exabytes). The full unit list: B, KB, MB, GB, TB, PB, EB.
 
----
-
-## Implementation
+**Implementation:**
 
 ```supersql
 const sk_bytes_units=["B", "KB", "MB", "GB", "TB", "PB", "EB"]

--- a/_build/recipes/integer.md
+++ b/_build/recipes/integer.md
@@ -34,6 +34,14 @@ sk_clamp(2, 2, 3)
 -- => 2
 ```
 
+**Implementation:**
+
+```supersql
+fn sk_clamp(i, min, max): (
+  i < min ? min : i > max ? max : i
+)
+```
+
 ---
 
 ## sk_min
@@ -53,6 +61,14 @@ sk_min(1, 2)
 
 sk_min(3, 2)
 -- => 2
+```
+
+**Implementation:**
+
+```supersql
+fn sk_min(a, b): (
+  a < b ? a : b
+)
 ```
 
 ---
@@ -76,19 +92,9 @@ sk_max(3, 2)
 -- => 3
 ```
 
----
-
-## Implementation
+**Implementation:**
 
 ```supersql
-fn sk_clamp(i, min, max): (
-    i < min ? min : i > max ? max : i
-)
-
-fn sk_min(a, b): (
-  a < b ? a : b
-)
-
 fn sk_max(a, b): (
   a > b ? a : b
 )

--- a/_build/recipes/records.md
+++ b/_build/recipes/records.md
@@ -26,6 +26,14 @@ into nested records.
 -- => ['x','y','z']
 ```
 
+**Implementation:**
+
+```supersql
+op sk_keys: (
+  fields(this) | unnest this | values this[0] | uniq | collect(this)
+)
+```
+
 ---
 
 ## sk_merge_records
@@ -38,6 +46,16 @@ there are duplicate keys, the last one wins.
 ```supersql
 [{a:1},{b:{c:333}}] | sk_merge_records
 -- => {a:1,b:{c:333}}
+```
+
+**Implementation:**
+
+```supersql
+op sk_merge_records: (
+  this::string
+  | replace(this, "},{",",")
+  | parse_sup(this[1:-1])
+)
 ```
 
 ---
@@ -53,23 +71,9 @@ Prepends an incrementing id field to each record. Always returns an array.
 -- => [{id:1,a:3},{id:2,b:4}]
 ```
 
----
-
-## Implementation
+**Implementation:**
 
 ```supersql
--- includes array.spq
-
-op sk_keys: (
-  fields(this) | unnest this | values this[0] | uniq | collect(this)
-)
-
-op sk_merge_records: (
-  this::string
-  | replace(this, "},{",",")
-  | parse_sup(this[1:-1])
-)
-
 op sk_add_ids: (
   sk_in_array(this)
   | unnest this

--- a/_build/recipes/string.md
+++ b/_build/recipes/string.md
@@ -28,6 +28,14 @@ sk_slice('howdy')
 -- => 'Howdy'
 ```
 
+**Implementation:**
+
+```supersql
+fn sk_slice(s, start, end): (
+  s[sk_clamp(start, -len(s), len(s)):sk_clamp(end, -len(s), len(s))]
+)
+```
+
 ---
 
 ## sk_capitalize
@@ -45,6 +53,14 @@ sk_capitalize('hoWDy')
 -- => 'Howdy'
 ```
 
+**Implementation:**
+
+```supersql
+fn sk_capitalize(s): (
+  f"{upper(sk_slice(s, 0, 1))}{lower(sk_slice(s,1,len(s)))}"
+)
+```
+
 ---
 
 ## sk_titleize
@@ -60,6 +76,14 @@ Splits string by space and capitalizes each word.
 ```supersql
 sk_titleize('once uPON A TIME')
 -- => 'Once Upon A Time'
+```
+
+**Implementation:**
+
+```supersql
+fn sk_titleize(s): (
+  [unnest split(s, " ") | values sk_capitalize(this)] | join(this, " ")
+)
 ```
 
 ---
@@ -81,6 +105,14 @@ values sk_pad_left('abc', ' ', 5)
 -- => '  abc'
 ```
 
+**Implementation:**
+
+```supersql
+fn sk_pad_left(s, pad_char, target_length): (
+  len(s) < target_length ? sk_pad_left(f'{pad_char}{s}', pad_char, target_length) : s
+)
+```
+
 ---
 
 ## sk_pad_right
@@ -100,6 +132,14 @@ values sk_pad_right('abc', ' ', 5)
 -- => 'abc  '
 ```
 
+**Implementation:**
+
+```supersql
+fn sk_pad_right(s, pad_char, target_length): (
+  len(s) < target_length ? sk_pad_right(f'{s}{pad_char}', pad_char, target_length) : s
+)
+```
+
 ---
 
 ## sk_urldecode
@@ -116,33 +156,9 @@ URL decoder for SuperDB. Splits on `%`, decodes each hex-encoded segment, and jo
 super -I string.spq -s -c 'values sk_urldecode("%2Ftavern%20test")' -
 ```
 
----
-
-## Implementation
+**Implementation:**
 
 ```supersql
--- includes integer.spq
-
-fn sk_slice(s, start, end): (
-  s[sk_clamp(start, -len(s), len(s)):sk_clamp(end, -len(s), len(s))]
-)
-
-fn sk_capitalize(s): (
-  f"{upper(sk_slice(s, 0, 1))}{lower(sk_slice(s,1,len(s)))}"
-)
-
-fn sk_titleize(s): (
-  [unnest split(s, " ") | values sk_capitalize(this)] | join(this, " ")
-)
-
-fn sk_pad_left(s, pad_char, target_length): (
-  len(s) < target_length ? sk_pad_left(f'{pad_char}{s}', pad_char, target_length) : s
-)
-
-fn sk_pad_right(s, pad_char, target_length): (
-  len(s) < target_length ? sk_pad_right(f'{s}{pad_char}', pad_char, target_length) : s
-)
-
 op sk_decode_seg s: (
   len(s) == 0
     ? s


### PR DESCRIPTION
## Summary
This PR adds implementation code blocks to all function and operator definitions across the recipe documentation. Each documented function now includes a "Implementation:" section showing the actual SuperSQL code that implements the function.

## Key Changes
- **string.md**: Added implementations for `sk_slice`, `sk_capitalize`, `sk_titleize`, `sk_pad_left`, `sk_pad_right`, and `sk_urldecode`
- **character.md**: Added implementations for `sk_seq`, `sk_hex_digits`, `sk_chr`, and `sk_alpha`
- **escape.md**: Added implementations for `sk_csv_field`, `sk_csv_row`, `sk_shell_quote`, and `sk_tsv_field`
- **records.md**: Added implementations for `sk_keys`, `sk_merge_records`, and `sk_add_ids`
- **integer.md**: Added implementations for `sk_clamp`, `sk_min`, and `sk_max`
- **array.md**: Added implementations for `sk_in_array` and `sk_array_flatten`
- **format.md**: Added implementations for `sk_format_bytes` and helper functions

## Notable Details
- All implementations are presented in properly formatted SuperSQL code blocks
- Implementations show the actual function/operator definitions used in the library
- This provides users with both the documented behavior (examples) and the actual implementation details for reference and learning

https://claude.ai/code/session_01Pooe7npja2susvNRDZkaAH