### PR TITLE
Release v0.3.0 changelog entry

### DIFF
--- a/changelog.jsup
+++ b/changelog.jsup
@@ -1,4 +1,16 @@
 {
+    date: "2026-03-27",
+    version: "0.3.0",
+    super_version: "v0.3.0",
+    items: [
+        "infra: update asdf-superdb to download official brimdata/super releases for v0.3.0+",
+        "infra: update superdb-mcp to v1.4.0 targeting SuperDB v0.3.0",
+        "docs: update all docs and tutorials to target SuperDB v0.3.0",
+        "docs: add v0.3.0 breaking changes to upgrade guide (BSUP v2, collect/union, concat/null)",
+        "docs: add v0.3.0 new features to expert guide (debug, infer, defuse, unblend, optional fields)"
+    ]
+}
+{
     date: "",
     version: "0.2.2",
     super_version: "",


### PR DESCRIPTION
## Summary
Add changelog entry for SuperDB v0.3.0 release documenting infrastructure updates, documentation changes, and new features.

## Changes
- Added v0.3.0 changelog entry with release date of 2026-03-27
- Documented infrastructure updates:
  - Updated asdf-superdb to download official brimdata/super releases for v0.3.0+
  - Updated superdb-mcp to v1.4.0 targeting SuperDB v0.3.0
- Documented documentation updates:
  - Updated all docs and tutorials to target SuperDB v0.3.0
  - Added v0.3.0 breaking changes to upgrade guide (BSUP v2, collect/union, concat/null)
  - Added v0.3.0 new features to expert guide (debug, infer, defuse, unblend, optional fields)

## Notes
This changelog entry captures the scope of work completed for the v0.3.0 release, including both infrastructure improvements and documentation updates to reflect the new version's capabilities and breaking changes.

https://claude.ai/code/session_01BR5uorn7SZjzvGzPettzFo